### PR TITLE
Rerun CI, pinned dependencies and upgraded toolbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ define _bumpversion
 	# upgrades as $(subst $(1),,$@) version, commits and tags
 	@docker run -it --rm -v $(PWD):/spinal-cord-toolbox \
 		-u $(shell id -u):$(shell id -g) \
-		itisfoundation/ci-service-integration-library:v1.0.1-dev-25 \
+		itisfoundation/ci-service-integration-library:v2.0.5 \
 		sh -c "cd /spinal-cord-toolbox && bump2version --verbose --list --config-file $(1) $(subst $(2),,$@)"
 endef
 
@@ -28,7 +28,7 @@ version-patch version-minor version-major: .bumpversion.cfg ## increases service
 compose-spec: ## runs ooil to assemble the docker-compose.yml file
 	@docker run -it --rm -v $(PWD):/spinal-cord-toolbox \
 		-u $(shell id -u):$(shell id -g) \
-		itisfoundation/ci-service-integration-library:v1.0.1-dev-25 \
+		itisfoundation/ci-service-integration-library:v2.0.5 \
 		sh -c "cd /spinal-cord-toolbox && ooil compose"
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ compose-spec: ## runs ooil to assemble the docker-compose.yml file
 
 .PHONY: build
 build: compose-spec ## build docker images
-	docker-compose build
+	docker compose build
 
 .PHONY: run-local
 run-local: ## runs images with local configuration
-	docker-compose --file docker-compose-local.yml up
+	docker compose --file docker-compose-local.yml up
 
 .PHONY: shell-app up
 shell-app: ## enter app container

--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ A template ci config file is created in ```.github/workflows/check-image.yml``) 
 
 The required CI is already packaged.
 To build and push to the internal registry you must add it to the [oSparc/docker-publisher-osparc-services](https://git.speag.com/oSparc/docker-publisher-osparc-services) repository.
+

--- a/README.md
+++ b/README.md
@@ -45,4 +45,3 @@ A template ci config file is created in ```.github/workflows/check-image.yml``) 
 
 The required CI is already packaged.
 To build and push to the internal registry you must add it to the [oSparc/docker-publisher-osparc-services](https://git.speag.com/oSparc/docker-publisher-osparc-services) repository.
-

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -71,7 +71,7 @@ RUN pip install virtualenv
 RUN virtualenv -p python3.8 /sct/fsleyes_env && \
     . /sct/fsleyes_env/bin/activate && \
     pip install --upgrade pip && \
-    pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk2/ubuntu-18.04 wxpython && \
+    pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk2/ubuntu-18.04 wxpython==4.1.1 && \
     pip install fsleyes
 
 ENV PATH="/sct/fsleyes_env/bin:${PATH}"

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -y && \
     net-tools \
     openbox \
     procps \
-    python3.8 \
+    python3.9 \
     python3-pip \
     supervisor \
     tigervnc-standalone-server \
@@ -51,7 +51,6 @@ ENV LANG=C.UTF-8
 
 FROM base AS production
 
-# TODO: Change according to your needs
 RUN apt-get update -y && \
     apt-get install -y curl bzip2 libglib2.0-0 gcc menu libsdl1.2debian libsdl2-2.0-0 freeglut3 libgtk2.0-0 libnotify4 && \
     rm -rf /var/lib/apt/lists 
@@ -59,6 +58,7 @@ RUN apt-get update -y && \
 # Install sct
 RUN git clone https://github.com/spinalcordtoolbox/spinalcordtoolbox.git sct && \
     cd sct && \
+    git checkout cae52ada6e4c7ec8c7e7fd8a8d05a2d2dfa1288f && \
     ./install_sct -y
 
 ENV PATH="/sct/bin:${PATH}"
@@ -68,7 +68,7 @@ ENV SCT_DIR=/sct
 # Install FSLeyes (for GUI part) in a new virtual environment
 
 RUN pip install virtualenv
-RUN virtualenv -p python3.8 /sct/fsleyes_env && \
+RUN virtualenv -p python3.9 /sct/fsleyes_env && \
     . /sct/fsleyes_env/bin/activate && \
     pip install --upgrade pip && \
     pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk2/ubuntu-18.04 wxpython==4.1.1 && \

--- a/app/config/supervisord.conf
+++ b/app/config/supervisord.conf
@@ -35,7 +35,7 @@ priority=1
 environment=DISPLAY=:0
 directory=/home/scu/work
 # TODO: Change according to you needs
-command=/sct/fsleyes_env/bin/fsleyes --runscript /sct/contrib/fsl_integration/sct_plugin.py --scene default
+command=/sct/fsleyes_env/bin/fsleyes --runscript /sct/contrib/fsl_integration/sct_fsleyes_script.py --scene default
 autorestart=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
Retriever CI run to make sure deploy CI becomes green
Upgraded:
- python form 3.8 -> 3.9
- spinal-cord-toolbox to 6.5
- pinned wxpython 4.1.1